### PR TITLE
Fix triggering verbs room portal bug

### DIFF
--- a/src/components/room-portal/room-portal.mjs
+++ b/src/components/room-portal/room-portal.mjs
@@ -33,8 +33,7 @@ export class RoomPortal extends GameObject {
   roomCallback() {
     const verb = document.body.dataset.verbActive;
     if (!verb) return;
-    if (verb in this.triggeringVerbs) {
-    // if (state.getActiveVerb() in this.triggeringVerbs) {
+    if (this.triggeringVerbs.includes(verb)) {
       loadRoom(this.room);
     }
   }


### PR DESCRIPTION
The triggering verbs property does not work properly, because I'm using
the `in` operator, which looks at object methods, not array contents.
The only verb name that "works" is push, since that is an array method.

Switch to `includes`, which actually does what we want.