### PR TITLE
Style actions menu

### DIFF
--- a/src/components/actions-menu/actions-menu.css
+++ b/src/components/actions-menu/actions-menu.css
@@ -1,0 +1,68 @@
+.actions-menu {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-around;
+  position: fixed;
+  overflow: auto;
+  background-color: #b08870;
+}
+
+@media screen and (orientation: portrait) {
+  body {
+    --actions-menu-size: 5em;
+  }
+
+  .stage {
+    height: calc(100vh - var(--actions-menu-size));
+  }
+
+  .actions-menu {
+    bottom: 0;
+    width: 100vw;
+    height: var(--actions-menu-size);
+    align-content: center;
+  }
+
+}
+
+@media screen and (orientation: landscape) {
+  body {
+    --actions-menu-size: 16ch;
+  }
+
+  .stage {
+    width: calc(100vw - var(--actions-menu-size));
+    margin-left: var(--actions-menu-size);
+  }
+
+  .actions-menu {
+    top: 0;
+    width: var(--actions-menu-size);
+    height: 100vh;
+    align-content: flex-start;
+  }
+}
+
+li {
+  margin: 3px;
+}
+
+button {
+  font-family: monospace, monospace;
+  font-size: 1.4rem;
+  border: 1px solid #000;
+  background: #94705a;
+  box-shadow: 2px 2px 0px #726f6f;
+  padding: 1ch;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:hover {
+  color: #fcfa7a;
+}
+
+button[aria-checked="true"] {
+  background-color: #674e3e;
+  box-shadow: inset 1px 1px 2px #000;
+}

--- a/src/components/actions-menu/actions-menu.mjs
+++ b/src/components/actions-menu/actions-menu.mjs
@@ -24,19 +24,23 @@ class ActionsMenu extends HTMLElement {
       `;
     });
 
-    this.innerHTML = `<ul role="menubar" class="actions-menu">${contents}</ul>`;
+    this.innerHTML = `<link rel="stylesheet" href="/src/components/actions-menu/actions-menu.css" />
+    <ul role="menubar" class="actions-menu">${contents}</ul>`;
 
     // Add state of current active verb to the stage data attribute.
-    this.addEventListener('pointerup', event => {
-      const element = event.target.closest('button');
-      if (!element) return;
-      const previousActive = this.querySelector('.verb[aria-checked="true"]');
+    document.documentElement.addEventListener('pointerup', event => {
+      const activeVerb = event.target.closest('button.verb');
+      const previousActive = document.querySelector('button.verb[aria-checked="true"]');
+      // Disable any previously enabled verbs.
       if (previousActive) {
+        document.body.dataset.verbActive = 'default';
         previousActive.setAttribute('aria-checked', 'false');
       }
-      element.setAttribute('aria-checked', 'true');
-      document.body.dataset.verbActive = element.id;
-      // state.setActiveVerb(element.id);
+      // If a non-button element was clicked, we're done.
+      if (!activeVerb) return;
+      // If the button was clicked, enable it and disable any previously clicked buttons.
+      activeVerb.setAttribute('aria-checked', 'true');
+      document.body.dataset.verbActive = activeVerb.id;
     }, false);
 
   }

--- a/src/components/text-display/text-display.css
+++ b/src/components/text-display/text-display.css
@@ -17,7 +17,7 @@
   bottom: 10px;
   left: 50%;
   transform: translateX(-50%);
-  font-family: monospace;
+  font-family: monospace, monospace;
   border: 2px solid var(--primary-color);
   box-shadow: 1px 1px 0px var(--secondary-color), -1px -1px 0px var(--secondary-color);
 }

--- a/src/pcg.css
+++ b/src/pcg.css
@@ -58,79 +58,19 @@ table {
 }
 
 body {
-  background-color: #fff;
   font-size: 1.7rem;
 }
 
 .stage {
+  background-color: #fff;
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc1JyBoZWlnaHQ9JzUnPgo8cmVjdCB3aWR0aD0nNScgaGVpZ2h0PSc1JyBmaWxsPScjZmZmJy8+CjxyZWN0IHdpZHRoPScxJyBoZWlnaHQ9JzEnIGZpbGw9JyNjY2MnLz4KPC9zdmc+);
+  background-repeat: repeat;
   position: relative;
   overflow: auto;
   width: 100vw;
   height: 100vh;
   cursor: crosshair;
 }
-
-.actions-menu {
-  display: flex;
-  position: fixed;
-  align-items: center;
-  overflow: auto;
-  width: 100vw;
-  height: 100vh;
-}
-
-.actions-menu > * {
-  flex: 0 0 auto;
-  margin: 0.5em;
-}
-
-@media screen and (orientation: portrait) {
-  body {
-    --actions-menu-size: 3em;
-  }
-
-  .stage {
-    height: calc(100vh - var(--actions-menu-size));
-  }
-
-  .actions-menu {
-    bottom: 0;
-    height: var(--actions-menu-size);
-    flex-flow: row nowrap;
-  }
-
-}
-
-@media screen and (orientation: landscape) {
-  body {
-    --actions-menu-size: 14ch;
-  }
-
-  .stage {
-    width: calc(100vw - var(--actions-menu-size));
-    margin-left: var(--actions-menu-size);
-  }
-
-  .actions-menu {
-    top: 0;
-    width: var(--actions-menu-size);
-    flex-flow: column nowrap;
-  }
-
-}
-
-/* Demo data {{{ */
-
-.actions-menu .game-object {
-  width: 5em;
-  height: 5em;
-}
-
-.actions-menu {
-  background-color: aquamarine;
-}
-
-/* }}} */
 
 /* vim: fdm=marker
  */


### PR DESCRIPTION
Add new stylesheet for actions menu styles. Move the actions menu
specific styles out of the main stylesheet and into this new one for
better organization.

Style the actions menu buttons with hovers, backgrounds, and a new
layout that stacks buttons 2-up when possible.

Add a background pattern for non-game space. Better distinction between
what is the play area and what isn't, and makes the engine feel a bit
more professional and designed.

Fix issue where the verb won't always reset back to default.